### PR TITLE
fix: clone issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "futures-loco-protocol"
-version = "0.4.0"
-authors = ["storycraft <storycraft@pancake.sh>"]
+version = "0.4.1"
+authors = ["storycraft <storycraft@pancake.sh>", "5-23 <rustacean@5-23.dev>"]
 license = "MIT"
 keywords = ["loco", "protocol", "futures"]
 readme = "readme.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,8 @@ use std::{
 };
 
 pin_project_lite::pin_project!(
-    #[derive(Debug)]
-    pub struct LocoClient<T> {
+    #[derive(Debug, Clone)]
+    pub struct LocoClient<T: Clone> {
         current_id: u32,
 
         sink: LocoSink,
@@ -32,7 +32,7 @@ pin_project_lite::pin_project!(
     }
 );
 
-impl<T> LocoClient<T> {
+impl<T: Clone> LocoClient<T> {
     pub const MAX_READ_SIZE: u64 = 16 * 1024 * 1024;
 
     pub const fn new(inner: T) -> Self {
@@ -65,7 +65,7 @@ impl<T> LocoClient<T> {
     }
 }
 
-impl<T: AsyncRead> LocoClient<T> {
+impl<T: AsyncRead + Clone> LocoClient<T> {
     pub async fn read(&mut self) -> io::Result<BoxedCommand>
     where
         T: Unpin,
@@ -124,7 +124,7 @@ impl<T: AsyncRead> LocoClient<T> {
     }
 }
 
-impl<T: AsyncWrite> LocoClient<T> {
+impl<T: AsyncWrite + Clone> LocoClient<T> {
     pub async fn send(&mut self, method: Method, data: &[u8]) -> io::Result<u32>
     where
         T: Unpin,
@@ -183,7 +183,7 @@ impl<T: AsyncWrite> LocoClient<T> {
     }
 }
 
-impl<T: AsyncRead + AsyncWrite + Unpin> LocoClient<T> {
+impl<T: AsyncRead + AsyncWrite + Unpin + Clone> LocoClient<T> {
     pub async fn request(
         &mut self,
         method: Method,
@@ -209,7 +209,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> LocoClient<T> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 enum ReadState {
     Pending,
     PacketTooLarge,

--- a/src/session.rs
+++ b/src/session.rs
@@ -19,7 +19,7 @@ pub struct LocoSession {
 }
 
 impl LocoSession {
-    pub fn new<T>(client: LocoClient<T>) -> (Self, LocoSessionStream<T>) {
+    pub fn new<T: Clone>(client: LocoClient<T>) -> (Self, LocoSessionStream<T>) {
         let (sender, receiver) = flume::bounded(16);
 
         (Self { sender }, LocoSessionStream::new(receiver, client))
@@ -42,7 +42,7 @@ impl LocoSession {
 }
 
 pin_project_lite::pin_project!(
-    pub struct LocoSessionStream<T> {
+    pub struct LocoSessionStream<T: Clone> {
         #[pin]
         request_stream: RecvStream<'static, Request>,
 
@@ -55,7 +55,7 @@ pin_project_lite::pin_project!(
     }
 );
 
-impl<T> LocoSessionStream<T> {
+impl<T: Clone> LocoSessionStream<T> {
     fn new(request_receiver: Receiver<Request>, client: LocoClient<T>) -> Self {
         Self {
             request_stream: request_receiver.into_stream(),
@@ -68,7 +68,7 @@ impl<T> LocoSessionStream<T> {
     }
 }
 
-impl<T: AsyncRead + AsyncWrite> Stream for LocoSessionStream<T> {
+impl<T: AsyncRead + AsyncWrite + Clone> Stream for LocoSessionStream<T> {
     type Item = io::Result<BoxedCommand>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {


### PR DESCRIPTION
LocoClient가 clone이 안되는 버그를 수정하였습니다
vscode의 rust-analyzer에서 lib.rs 21L에 오류가 있다 알려줄수 있지만 build시 실제로는 일어나지 않는 오류니 그냥 무시하시면 됩니다.